### PR TITLE
Closed helptext preformatted block

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Usage: ./src/nfc-iclass [options] [BINARY FILE|HEX DATA]
 	-w <BLOCK>    WRITE to tag starting from BLOCK (specify # in HEX)
 
 	If no KEY is specified, default HID Kd (APP1) will be used
-
+```
 ### Examples
 
 Use ELITE key for APP1:


### PR DESCRIPTION
Looks like the help text preformatted block didn't get closed, but with all the stuff that is preformatted, it wasn't noticable until the config cards header towards the bottom.